### PR TITLE
Fix bug in pk_MoveItem ToIndex default value.

### DIFF
--- a/Packets.h
+++ b/Packets.h
@@ -83,7 +83,7 @@ struct pk_MoveItem
         , FromStorage(0)
         , ToStorage(0)
         , FromIndex(0)
-        , ToIndex(81)
+        , ToIndex(82)
     {}
 };
 


### PR DESCRIPTION
The latest retail client appears to use 0x52 as well when moving items into a container without a specific index.